### PR TITLE
Fix off-by-one error.

### DIFF
--- a/mantohtml.c
+++ b/mantohtml.c
@@ -1522,7 +1522,7 @@ man_xx(man_state_t *state,		// I - Current man state
 
 
   // Loop until all words are written
-  while (parse_value(word, &line, sizeof(word)))
+  while (parse_value(word, &line, sizeof(word)-1))
   {
     html_font(state, use_a ? a : b);
     use_a = !use_a;


### PR DESCRIPTION
This is a minimum viable patch to issue described in #1. This sets the size to 255 instead of 256, which prevents `parse_value` from overflowing the buffer pointed to by `word`. I'm not sure how this will effect the rest of the logic and if other characters will end up missing as a result. However, I did test it with the included `mantohtml.1` and the `diff` of the html before and after this patch were identical.

Resolves #1 